### PR TITLE
Enable sample schedules on small screens.

### DIFF
--- a/public/css/css.css
+++ b/public/css/css.css
@@ -209,10 +209,9 @@ p,.list li{
   }
 }
 
-/*#canvasResizer {
-	width:100%;
-	height:100%;
-}*/
+#canvasResizer {
+	order: 1
+}
 
 #footer{
 	background-color: #F44336;
@@ -265,8 +264,12 @@ Schedule chooser
 }
 
 @media (max-width: 600px) {
+	.flex {
+		display: flex;
+		flex-direction: column;
+	}
   .sampleSchedules-col {
-    display: none;
+		order: 2;
   }
 }
 
@@ -379,6 +382,9 @@ Schedule chooser
 /**************************
 11.0   Settings
 *******************/
+#settingsRow {
+	order: 3;
+}
 .settingsElement:not(:first-child){
 	padding-top: 10px
 }

--- a/views/pages/main.ejs
+++ b/views/pages/main.ejs
@@ -64,22 +64,28 @@
 
 
 
-                <div class="row">
-
+                <div class="row flex">
                     <div class="col s12 m2 l2 sampleSchedules-col">
-                        <div class="card stat-block transparent">
-                            <div id="sampleSchedules">
-                                <div id="none" class=""></div>
-                                <div id="scheduleIndicator"></div>
-                                <div id="monophasic" class="sampleSchedule">Monophasic</div>
-                                <div id='segmented' class='sampleSchedule'>Segmented</div>
-                                <div id='siesta' class='sampleSchedule'>Siesta</div>
-                                <div id='dualcore1' class='sampleSchedule'>Dual Core 1</div>
-                                <div id='triphasic' class='sampleSchedule'>Triphasic</div>
-                                <div id='everyman' class='sampleSchedule'>Everyman</div>
-                                <div id='uberman' class='sampleSchedule'>Uberman</div>
+                      <ul class="collapsible" data-collapsible="accordion">
+                          <li>
+                            <div class="collapsible-header active">
+                              Schedules▼
                             </div>
-                        </div>
+                            <div class="collapsible-body">
+                              <div id="sampleSchedules">
+                                  <div id="none" class=""></div>
+                                  <div id="scheduleIndicator"></div>
+                                  <div id="monophasic" class="sampleSchedule">Monophasic</div>
+                                  <div id='segmented' class='sampleSchedule'>Segmented</div>
+                                  <div id='siesta' class='sampleSchedule'>Siesta</div>
+                                  <div id='dualcore1' class='sampleSchedule'>Dual Core 1</div>
+                                  <div id='triphasic' class='sampleSchedule'>Triphasic</div>
+                                  <div id='everyman' class='sampleSchedule'>Everyman</div>
+                                  <div id='uberman' class='sampleSchedule'>Uberman</div>
+                              </div>
+                            </div>
+                          </li>
+                        </ul>
                     </div>
 
                     <div id="canvasResizer" class="col s12 m6 l6">
@@ -87,7 +93,7 @@
                         </canvas>
                     </div>
 
-                    <div class="col s12 m4 l4">
+                    <div class="col s12 m4 l4" id="settingsRow">
 
 
                         <div class="card stat-block" id="settings">

--- a/views/partials/scripts.ejs
+++ b/views/partials/scripts.ejs
@@ -20,3 +20,5 @@
 <script src="js/textSerialize.js"></script>
 <script src="js/napchartCore.js"></script>
 <script src="js/application.js"></script>
+<!-- Compiled and minified JavaScript -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.6/js/materialize.min.js"></script>


### PR DESCRIPTION
#9 Made a collapsible select for sample schedules

I used flexbox order to make the schedules appear below the clock on
small screens
By default the view is opened. This could be changed on mobile by
removing (or adding later) the active attribute in the collapsible
header tag.
